### PR TITLE
Add untag command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,7 +17,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+            "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_MISSING_TAG =
+            "Tags [%2$s] not found for %1$s";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -1,0 +1,107 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Deletes a tag from a person with its displayed index.
+ */
+public class UntagCommand extends Command {
+    public static final String COMMAND_WORD = "untag";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the tag from contact identified by the index number used in the displayed contact list.\n"
+            + "Parameters: INDEX (must be a positive integer) t/TAG [t/TAG]...\n"
+            + "Example: " + COMMAND_WORD + "1 t/friends";
+
+    public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted tag %2$s from %1$s";
+
+    private final Index index;
+    private final Set<Tag> tags;
+
+    /**
+     * Creates a command to delete a {@code tag} from the person at {@code index}.
+     */
+    public UntagCommand(Index index, Collection<Tag> tags) {
+        this.index = index;
+        this.tags = new HashSet<>(tags);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        var lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() > lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        var personToUntag = lastShownList.get(index.getZeroBased());
+        var untaggedPerson = untag(personToUntag);
+        model.setPerson(personToUntag, untaggedPerson);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(
+                MESSAGE_DELETE_TAG_SUCCESS,
+                Messages.format(untaggedPerson),
+                showTags(tags)));
+    }
+
+    private Person untag(Person personToUntag) throws CommandException {
+        var personTags = new HashSet<Tag>(personToUntag.getTags());
+
+        validateAllTagsExist(personToUntag, personTags);
+        personTags.removeAll(tags);
+
+        return new Person(
+                personToUntag.getName(),
+                personToUntag.getPhone(),
+                personToUntag.getEmail(),
+                personToUntag.getAddress(),
+                personTags);
+    }
+
+    private void validateAllTagsExist(Person personToUntag, HashSet<Tag> personTags) throws CommandException {
+        var missingTagNames = tags
+                .stream()
+                .filter((tag) -> !personTags.contains(tag))
+                .collect(Collectors.toList());
+        if (!missingTagNames.isEmpty()) {
+            throw new CommandException(
+                    String.format(
+                            Messages.MESSAGE_MISSING_TAG,
+                            personToUntag.getName(),
+                            showTags(missingTagNames)));
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other instanceof UntagCommand) {
+            UntagCommand obj = (UntagCommand) other;
+            return index.equals(obj.index) && tags.equals(obj.tags);
+        }
+
+        return false;
+    }
+
+    private static String showTags(Collection<Tag> tags) {
+        return tags.stream().map((tag) -> tag.tagName)
+                .sorted() // making the output order deterministic
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UntagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -73,6 +74,9 @@ public class AddressBookParser {
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
+
+        case UntagCommand.COMMAND_WORD:
+            return new UntagCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();

--- a/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.UntagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates an UntagCommand.
+ */
+public class UntagCommandParser implements Parser<UntagCommand> {
+    @Override
+    public UntagCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_TAG);
+
+        var tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        if (tags.isEmpty()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
+        }
+
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+
+        return new UntagCommand(index, tags);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -1,5 +1,13 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -14,14 +22,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 /**
  * Contains integration tests (interactions with the Model) and unit tests for UntagCommand.

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -1,21 +1,12 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-
 import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -24,13 +15,21 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
 /**
  * Contains integration tests (interactions with the Model) and unit tests for UntagCommand.
  */
 class UntagCommandTest {
-    private static final Tag TAG_FRIEND = new Tag(VALID_TAG_FRIEND);
-    private static final Tag TAG_HUSBAND = new Tag(VALID_TAG_HUSBAND);
-    private static final Collection<Tag> TAGS = List.of(TAG_FRIEND, TAG_HUSBAND);
+    private static final Tag TAG_OWES_MONEY = new Tag("owesMoney");
+    private static final Tag TAG_FRIENDS = new Tag("friends");
+    private static final Collection<Tag> TAGS = List.of(TAG_OWES_MONEY, TAG_FRIENDS);
 
     private Model model;
 
@@ -41,10 +40,8 @@ class UntagCommandTest {
 
     @Test
     public void execute_multipleTagsSpecified_success() {
-        List<Tag> tags = List.of(new Tag("owesMoney"), new Tag("friends"));
         var index = INDEX_SECOND_PERSON;
-        var command = new UntagCommand(index, tags);
-
+        var command = new UntagCommand(index, TAGS);
         var actualPerson = model.getFilteredPersonList().get(index.getZeroBased());
 
         var editedPerson = new PersonBuilder(actualPerson).withTags().build();
@@ -62,11 +59,8 @@ class UntagCommandTest {
     @Test
     public void execute_tagMissing_failure() {
         var index = INDEX_FIRST_PERSON;
-        List<Tag> tags = List.of(new Tag("owesMoney"), new Tag("friends"));
-
         var personName = model.getFilteredPersonList().get(index.getZeroBased()).getName();
-
-        var command = new UntagCommand(index, tags);
+        var command = new UntagCommand(index, TAGS);
 
         var expectedMessage = String.format(
                 Messages.MESSAGE_MISSING_TAG,
@@ -77,15 +71,27 @@ class UntagCommandTest {
     }
 
     @Test
+    public void execute_indexOutOfBounds_failure() {
+        var index = Index.fromOneBased(999);
+        var command = new UntagCommand(index, TAGS);
+
+        var expectedMessage = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+        assertCommandFailure(command, model, expectedMessage);
+    }
+
+    @Test
     public void equals() {
         final UntagCommand standardCommand = new UntagCommand(INDEX_FIRST_PERSON, TAGS);
+
+        // same object -> equal
+        assertEquals(standardCommand, standardCommand);
 
         // same values -> equal
         var commandWithSameValues = new UntagCommand(INDEX_FIRST_PERSON, TAGS);
         assertEquals(standardCommand, commandWithSameValues);
 
         // tags in different order -> equal
-        var tagsInDifferentOrder = List.of(TAG_HUSBAND, TAG_FRIEND);
+        var tagsInDifferentOrder = List.of(TAG_FRIENDS, TAG_OWES_MONEY);
         assertEquals(standardCommand, new UntagCommand(INDEX_FIRST_PERSON, tagsInDifferentOrder));
 
         // null -> not equal
@@ -98,6 +104,6 @@ class UntagCommandTest {
         assertNotEquals(standardCommand, new UntagCommand(INDEX_SECOND_PERSON, TAGS));
 
         // different tags -> not equal
-        assertNotEquals(standardCommand, new UntagCommand(INDEX_FIRST_PERSON, List.of(TAG_FRIEND)));
+        assertNotEquals(standardCommand, new UntagCommand(INDEX_FIRST_PERSON, List.of(TAG_OWES_MONEY)));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -1,0 +1,103 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interactions with the Model) and unit tests for UntagCommand.
+ */
+class UntagCommandTest {
+    private static final Tag TAG_FRIEND = new Tag(VALID_TAG_FRIEND);
+    private static final Tag TAG_HUSBAND = new Tag(VALID_TAG_HUSBAND);
+    private static final Collection<Tag> TAGS = List.of(TAG_FRIEND, TAG_HUSBAND);
+
+    private Model model;
+
+    @BeforeEach
+    public void init() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_multipleTagsSpecified_success() {
+        List<Tag> tags = List.of(new Tag("owesMoney"), new Tag("friends"));
+        var index = INDEX_SECOND_PERSON;
+        var command = new UntagCommand(index, tags);
+
+        var actualPerson = model.getFilteredPersonList().get(index.getZeroBased());
+
+        var editedPerson = new PersonBuilder(actualPerson).withTags().build();
+        var expectedMessage = String.format(
+                UntagCommand.MESSAGE_DELETE_TAG_SUCCESS,
+                Messages.format(editedPerson),
+                "friends, owesMoney");
+
+        var expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(actualPerson, editedPerson);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_tagMissing_failure() {
+        var index = INDEX_FIRST_PERSON;
+        List<Tag> tags = List.of(new Tag("owesMoney"), new Tag("friends"));
+
+        var personName = model.getFilteredPersonList().get(index.getZeroBased()).getName();
+
+        var command = new UntagCommand(index, tags);
+
+        var expectedMessage = String.format(
+                Messages.MESSAGE_MISSING_TAG,
+                personName,
+                "owesMoney");
+
+        assertCommandFailure(command, model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        final UntagCommand standardCommand = new UntagCommand(INDEX_FIRST_PERSON, TAGS);
+
+        // same values -> equal
+        var commandWithSameValues = new UntagCommand(INDEX_FIRST_PERSON, TAGS);
+        assertEquals(standardCommand, commandWithSameValues);
+
+        // tags in different order -> equal
+        var tagsInDifferentOrder = List.of(TAG_HUSBAND, TAG_FRIEND);
+        assertEquals(standardCommand, new UntagCommand(INDEX_FIRST_PERSON, tagsInDifferentOrder));
+
+        // null -> not equal
+        assertNotEquals(null, standardCommand);
+
+        // different types -> not equal
+        assertNotEquals(standardCommand, new ClearCommand());
+
+        // different index -> not equal
+        assertNotEquals(standardCommand, new UntagCommand(INDEX_SECOND_PERSON, TAGS));
+
+        // different tags -> not equal
+        assertNotEquals(standardCommand, new UntagCommand(INDEX_FIRST_PERSON, List.of(TAG_FRIEND)));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,9 +22,11 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UntagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -86,6 +88,16 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_untag() throws Exception {
+        var index = INDEX_FIRST_PERSON;
+        var expectedCommand = new UntagCommand(index, List.of(new Tag("alpha"), new Tag("beta")));
+        assertEquals(expectedCommand, parser.parseCommand(UntagCommand.COMMAND_WORD
+                + " "
+                + INDEX_FIRST_PERSON.getOneBased()
+                + " t/alpha t/beta"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UntagCommand;
+import seedu.address.model.tag.Tag;
+
+class UntagCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE);
+
+    private static final Tag TAG1 = new Tag("friend");
+    private static final Tag TAG2 = new Tag("husband");
+
+    private static final Collection<Tag> TAGS = List.of(TAG1, TAG2);
+
+    private final UntagCommandParser parser = new UntagCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUntagCommand() {
+        var index = INDEX_FIRST_PERSON;
+        assertParseSuccess(parser, index.getOneBased() + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+                new UntagCommand(index, TAGS));
+
+        // order should not matter
+        assertParseSuccess(parser, index.getOneBased() + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                new UntagCommand(index, TAGS));
+
+        // one tag
+        assertParseSuccess(parser, index.getOneBased() + TAG_DESC_HUSBAND,
+                new UntagCommand(index, List.of(TAG2)));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // no tags given
+        assertParseFailure(parser, "1",
+                MESSAGE_INVALID_FORMAT);
+
+        // no index given
+        assertParseFailure(parser, "t/friend",
+                MESSAGE_INVALID_FORMAT);
+    }
+}


### PR DESCRIPTION
As a counterpart to the tagging command, this command untags a user from some tags.

This implementation can do multiple tags at the same time to amke removing tags faster. It throws an error on non matching tags, but that can be changed if that is not desirable e.g. if batch operations are introduced.

Closes #6